### PR TITLE
Add adjustable scrollOffset to make see/click work with sticky headers

### DIFF
--- a/action_helpers/browser_side_scripts.js
+++ b/action_helpers/browser_side_scripts.js
@@ -231,15 +231,9 @@ var browserSideFind = function(locators, opt_options) {
 
   var scrollIntoView = function(el) {
     // scroll to the element
-    el.scrollIntoView(true);
-
-    // shift into view if needed
-    if (!hasCorrectDisplayStatus(element) && opt_options.scrollOffset) {
-      var scrolledY = window.scrollY;
-      if (scrolledY) {
-        window.scroll(0, scrolledY - opt_options.scrollOffset);
-      }
-    }
+    const scrollOffset = opt_options.scrollOffset || 0;
+    const top = el.offsetTop - scrollOffset;
+    window.scroll({ top });
   }
 
   // Finds exactly one element globally (or zero if locator.wantZero is set).

--- a/action_helpers/browser_side_scripts.js
+++ b/action_helpers/browser_side_scripts.js
@@ -229,6 +229,19 @@ var browserSideFind = function(locators, opt_options) {
     return s;
   };
 
+  var scrollIntoView = function(el) {
+    // scroll to the element
+    el.scrollIntoView(true);
+
+    // shift into view if needed
+    if (!hasCorrectDisplayStatus(element) && opt_options.scrollOffset) {
+      var scrolledY = window.scrollY;
+      if (scrolledY) {
+        window.scroll(0, scrolledY - opt_options.scrollOffset);
+      }
+    }
+  }
+
   // Finds exactly one element globally (or zero if locator.wantZero is set).
   var findGlobal = function(locator) {
     if (locator.direction === 'at') {
@@ -243,7 +256,7 @@ var browserSideFind = function(locators, opt_options) {
     if (!candidateElements.length && options.scroll !== false) {
       var maybeDisplayed = all.filter(isMaybeDisplayed);
       if (maybeDisplayed.length == 1 && shouldAutoScroll(maybeDisplayed[0])) {
-        maybeDisplayed[0].scrollIntoView();
+        scrollIntoView(maybeDisplayed[0]);
         if (hasCorrectDisplayStatus(maybeDisplayed[0])) {
           candidateElements = maybeDisplayed;
         }
@@ -356,7 +369,7 @@ var browserSideFind = function(locators, opt_options) {
         return isMaybeDisplayed(e.element);
       });
       if (maybeDisplayed.length) {
-        maybeDisplayed[0].element.scrollIntoView();
+        scrollIntoView(maybeDisplayed[0].element);
         candidateElements = all.filter(function(e) {
           return hasCorrectDisplayStatus(e.element);
         });
@@ -541,7 +554,7 @@ var browserSideFind = function(locators, opt_options) {
           elementsToString(maybeDisplayed);
     }
     var e = maybeDisplayed[0];
-    e.scrollIntoView();
+    scrollIntoView(e);
     if (!hasCorrectDisplayStatus(e)) {
       throw 'Scrolling to ' + locatorToString(locator) + ' failed. The ' +
           'displayable element did not become displayed after ' +

--- a/action_helpers/browser_side_scripts.js
+++ b/action_helpers/browser_side_scripts.js
@@ -232,8 +232,8 @@ var browserSideFind = function(locators, opt_options) {
   var scrollIntoView = function(el) {
     // scroll to the element
     const scrollOffset = opt_options.scrollOffset || 0;
-    const top = el.offsetTop - scrollOffset;
-    window.scroll({ top });
+    const scrollY = el.offsetTop - scrollOffset;
+    window.scroll({ top: scrollY > 0 ? scrollY : 0 });
   }
 
   // Finds exactly one element globally (or zero if locator.wantZero is set).

--- a/action_helpers/find.ts
+++ b/action_helpers/find.ts
@@ -21,6 +21,7 @@ export interface BrowserSideOptions {
   wantZero?: boolean;
   enabled?: boolean;
   disabled?: boolean;
+  scrollOffset?: number;
 }
 
 /**


### PR DESCRIPTION
Fixes `see(foo)` when the page has a sticky header or other content.
Native `scrollIntoView()` will scroll the element to the top of the page,
which will be behind the header. The element is thus not visible.

The usage is not great because it's just a "global" `setOffset`
at the top of your spec. Suggestions welcome.